### PR TITLE
set_client-cert_to_squid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .python-version
+credentials.yml

--- a/credentials.yml.example
+++ b/credentials.yml.example
@@ -1,0 +1,9 @@
+---
+dockerhub_login_user: NAME
+dockerhub_login_password: PASSWORD
+nssdc_client_cert: |
+  -----BEGIN CERTIFICATE-----
+  -----END CERTIFICATE-----
+nssdc_client_key: |
+  -----BEGIN RSA PRIVATE KEY-----
+  -----END RSA PRIVATE KEY-----

--- a/setup.yml
+++ b/setup.yml
@@ -53,6 +53,27 @@
       regexp: '^#? *hosts_file.*'
       line: 'hosts_file /etc/squid/hosts' 
     notify: 'config changed'
+  - name: create client cert directory
+    file:
+      path: /etc/squid/client_cert
+      state: directory
+      mode: "644"
+  - name: put client cert and key
+    blockinfile:
+      path: "/etc/squid/client_cert/{{ item.name }}"
+      block: "{{ item.content }}"
+      create: true
+      marker: "# {mark} ANSIBLE MANAGED BLOCK for {{ item.name }}"
+    loop:
+      - { name: client.crt, content: "{{ nssdc_client_cert }}" }
+      - { name: client.key, content: "{{ nssdc_client_key }}" }
+  - name: set client cert to squid
+    blockinfile:
+      path: /etc/squid/squid.conf
+      insertafter: "# tls_outgoing_options flags=DONT_VERIFY_PEER,DONT_VERIFY_DOMAIN"
+      block: |
+        tls_outgoing_options cert=/etc/squid/client_cert/client.crt key=/etc/squid/client_cert/client.key
+    notify: 'config changed'
   handlers:
   - name: send HUP signal to recconfigure
     shell: kill -HUP 1


### PR DESCRIPTION
# WHAT
squid にクライアント証明書と鍵を設定するように変更を行った。
# WHY
ssl_bump が設定された squid を経由して、クライアント証明書を要求するサイトにアクセスする場合、クライアントからサーバへクライアント証明書と鍵を送ることができない。
そのため、squid からサーバへクライアント証明書を送るように、設定の変更を行った。