### PR TITLE
Feature/store nginx redirect url files

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,9 @@ services:
   nginx:
     build: nginx
     container_name: nginx
+    volumes:
+      - nginx_config:/etc/nginx
+      - nginx_data:/usr/share/nginx/html
   registry:
     image: registry
     container_name: registry
@@ -37,3 +40,5 @@ volumes:
   registry:
   registry_config:
   devpi_dir:
+  nginx_config:
+  nginx_data:

--- a/offline.yml
+++ b/offline.yml
@@ -104,3 +104,15 @@
   - name: install python
     raw: apt-get update ; apt-get -y install python3
     changed_when: False
+  - name: insert location directive
+    blockinfile:
+      path: "/etc/nginx/conf.d/default.conf"
+      insertafter: "ssl_certificate_key /etc/ssl/private/domain.key;"
+      block: |
+        {% set filename = item.split('/')[-1] %}
+        location {{ item }} {
+          alias /usr/share/nginx/html/downloads/{{ filename }};
+        }
+      marker: "# {mark} ANSIBLE MANAGED BLOCK for {{ item }}"
+    loop: "{{ hostvars['squid'].file_paths.stdout_lines }}"
+    notify: 'nginx config changed'

--- a/offline.yml
+++ b/offline.yml
@@ -96,3 +96,11 @@
   - name: send HUP signal to recconfigure
     shell: kill -HUP 1
     listen: 'config changed'
+- name: Download files to nginx via redirect
+  hosts: nginx
+  connection: docker
+  gather_facts: no
+  tasks:
+  - name: install python
+    raw: apt-get update ; apt-get -y install python3
+    changed_when: False

--- a/offline.yml
+++ b/offline.yml
@@ -82,6 +82,16 @@
       regexp: '^#? *tls_outgoing_options.*'
       line: 'tls_outgoing_options flags=DONT_VERIFY_PEER,DONT_VERIFY_DOMAIN' 
     notify: 'config changed'
+  - name: gather URLs which return redirect from access log
+    shell: "sed -n -e 's/^.*GET \\([^\\?]*\\) HTTP\\/1\\.1. 30[0-9].*$/\\1/p' /var/log/squid/access.log | sort | uniq"
+    changed_when: false
+    check_mode: false
+    register: redirect_urls
+  - name: gather file paths
+    shell: "sed -n -e 's/^.*GET https:\\/\\/[^\\/]*\\(\\/[^\\?]*\\) HTTP\\/1\\.1. 30[0-9].*$/\\1/p' /var/log/squid/access.log | sort | uniq"
+    changed_when: false
+    check_mode: false
+    register: file_paths
   handlers:
   - name: send HUP signal to recconfigure
     shell: kill -HUP 1

--- a/offline.yml
+++ b/offline.yml
@@ -129,3 +129,6 @@
     loop: "{{ hostvars['squid'].redirect_urls.stdout_lines }}"
     ignore_errors: yes
   handlers:
+  - name: send HUP signal to recconfigure
+    shell: kill -HUP 1
+    listen: 'nginx config changed'

--- a/offline.yml
+++ b/offline.yml
@@ -116,3 +116,16 @@
       marker: "# {mark} ANSIBLE MANAGED BLOCK for {{ item }}"
     loop: "{{ hostvars['squid'].file_paths.stdout_lines }}"
     notify: 'nginx config changed'
+  - name: create downloads directory
+    file:
+      path: /usr/share/nginx/html/downloads
+      state: directory
+      mode: "755"
+  - name: gather files through redirect
+    get_url:
+      url: "{{ item }}"
+      dest: /usr/share/nginx/html/downloads/
+      mode: '644'
+    loop: "{{ hostvars['squid'].redirect_urls.stdout_lines }}"
+    ignore_errors: yes
+  handlers:


### PR DESCRIPTION
# What
リダイレクトを返すURLから最終的に得られるファイルを、nginxに保存する機能を追加
# Why
オンラインの状態でアクセスしたURLがリダイレクトを返す場合、squidにキャッシュができず、オフライン化してそのURLにアクセスした時に想定した動作にならない。
そのため、リダイレクトを返すURLについては、squidのアクセスログからURLを取得して、そこから得られるファイルをnginxに保存するようにする。
そうすることで、オフライン化した時はnginxからファイルを取得するようにする。