### PR TITLE
squidのhostsファイルを再設定するplaybookを追加

### DIFF
--- a/reset-squid-hosts.yml
+++ b/reset-squid-hosts.yml
@@ -1,0 +1,60 @@
+---
+- name: reset squid hosts file
+  hosts: squid
+  connection: docker
+  gather_facts: no
+  tasks:
+  - name: install python
+    raw: apt-get update ; apt-get -y install python3
+    changed_when: False
+  - name: delete squid hosts file
+    file:
+      path: /etc/squid/hosts
+      state: absent
+  - name: create squid hosts file
+    file:
+      path: /etc/squid/hosts
+      state: touch
+      mode: 0644
+  - name: get ip address of registry
+    shell: "echo $(getent hosts registry | cut -d ' ' -f 1)"
+    changed_when: false
+    check_mode: false
+    register: registry_addr
+  - name: get ip address of devpi-server
+    shell: "echo $(getent hosts devpi-server | cut -d ' ' -f 1)"
+    changed_when: false
+    check_mode: false
+    register: devpi_server_addr
+  - name: get ip address of nginx
+    shell: "echo $(getent hosts nginx | cut -d ' ' -f 1)"
+    changed_when: false
+    check_mode: false
+    register: nginx_addr
+  - name: gather hosts which uses TLS from access log
+    shell: "sed -n -e 's/^.*CONNECT \\([^:]*\\):.*$/\\1/p' /var/log/squid/access.log | sort | uniq"
+    changed_when: false
+    check_mode: false
+    register: tls_hosts
+  - name: edit tls_hosts
+    shell: "echo {{ tls_hosts.stdout_lines | join(' ') }} | sed -e 's/registry-mirror\\.offline-cache//g' | sed -e 's/devpi-server\\.offline-cache//g'"
+    changed_when: false
+    check_mode: false
+    register: edited_tls_hosts
+  - name: add entry into hosts file for squid
+    lineinfile:
+      insertafter: EOF
+      line: "{{ item.address }} {{ item.name }}"
+      dest: /etc/squid/hosts
+    loop:
+      - name: registry-mirror.offline-cache
+        address: "{{ registry_addr.stdout_lines | first }}"
+      - name: devpi-server.offline-cache
+        address: "{{ devpi_server_addr.stdout_lines | first }}"
+      - name: "{{ edited_tls_hosts.stdout_lines | first }}"
+        address: "{{ nginx_addr.stdout_lines | first }}"
+    notify: 'config changed'
+  handlers:
+  - name: send HUP signal to recconfigure
+    shell: kill -HUP 1
+    listen: 'config changed'


### PR DESCRIPTION
# What
squidのhostsファイルを再設定するplaybookを追加
# Why
マザーマシンを再起動した場合など、squid の hosts ファイルの設定とコンテナの IP アドレスのずれが発生する。
squid の hosts ファイルの再設定を行い、ずれを解消するための playbook を追加した。