### PR TITLE
Fix redirect download 80 etc

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,5 +1,6 @@
 server {
-    listen 443 ssl http2;
+    listen 443 ssl;
+    http2 on;
     server_name registry-1.docker.io;
 
     charset utf8;

--- a/offline.yml
+++ b/offline.yml
@@ -53,45 +53,60 @@
     changed_when: false
     check_mode: false
     register: tls_hosts
+  - name: gather URLs which return redirect from access log
+    shell: "sed -n -e 's/^.*GET \\([^\\?]*\\) HTTP\\/1\\.1. 30[0-9].*$/\\1/p' /var/log/squid/access.log | sort | uniq"
+    changed_when: false
+    check_mode: false
+    register: redirect_urls
+  - name: gather file paths which return redirect from access log (http)
+    shell: "sed -n -e 's/^.*GET http:\\/\\/[^\\/]*\\(\\/[^\\?]*\\) HTTP\\/1\\.1. 30[0-9].*$/\\1/p' /var/log/squid/access.log | sort | uniq"
+    changed_when: false
+    check_mode: false
+    register: file_paths_http
+  - name: gather file paths which return redirect from access log (https)
+    shell: "sed -n -e 's/^.*GET https:\\/\\/[^\\/]*\\(\\/[^\\?]*\\) HTTP\\/1\\.1. 30[0-9].*$/\\1/p' /var/log/squid/access.log | sort | uniq"
+    changed_when: false
+    check_mode: false
+    register: file_paths_https
+  - name: gather directory paths which return redirect from access log
+    shell: "sed -n -e 's/^.*GET https*:\\/\\/[^\\/]*\\(\\/[^\\?]*\\)\\/[^\\?]* HTTP\\/1\\.1. 30[0-9].*$/\\1/p' /var/log/squid/access.log | sort | uniq"
+    changed_when: false
+    check_mode: false
+    register: directory_paths
+  - name: gather domains which return redirect from access log
+    shell: "sed -n -e 's/^.*GET https*:\\/\\/\\([^\\/]*\\)\\/[^\\?]* HTTP\\/1\\.1. 30[0-9].*$/\\1/p' /var/log/squid/access.log | sort | uniq"
+    changed_when: false
+    check_mode: false
+    register: redirect_domains
   - name: get ip address of nginx
     shell: "echo $(getent hosts nginx | cut -d ' ' -f 1)"
     changed_when: false
     check_mode: false
     register: nginx_addr
-  - name: add entry TLS hosts into hosts file for squid
+  - name: add entry TLS hosts and redirect domains into hosts file for squid
     lineinfile:
       insertafter: EOF
-      line: "{{ nginx_addr.stdout_lines | first }} {{ tls_hosts.stdout_lines | join(' ') }}"
+      line: "{{ nginx_addr.stdout_lines | first }} {{ ( tls_hosts.stdout_lines | union(redirect_domains.stdout_lines) ) | join(' ') }}"
       dest: /etc/squid/hosts
     notify: 'config changed'
   - name: set sslproxy_cert_error directive in squid.conf
     lineinfile:
       dest: /etc/squid/squid.conf
       regexp: '^#? *sslproxy_cert_error.*'
-      line: 'sslproxy_cert_error allow all' 
+      line: 'sslproxy_cert_error allow all'
     notify: 'config changed'
   - name: set sslproxy_cert_adapt directive in squid.conf
     lineinfile:
       dest: /etc/squid/squid.conf
       regexp: '^#? *sslproxy_cert_adapt.*'
-      line: 'sslproxy_cert_adapt setCommonName all' 
+      line: 'sslproxy_cert_adapt setCommonName all'
     notify: 'config changed'
   - name: set tls_outgoing_options directive in squid.conf
     lineinfile:
       dest: /etc/squid/squid.conf
       regexp: '^#? *tls_outgoing_options.*'
-      line: 'tls_outgoing_options flags=DONT_VERIFY_PEER,DONT_VERIFY_DOMAIN' 
+      line: 'tls_outgoing_options flags=DONT_VERIFY_PEER,DONT_VERIFY_DOMAIN'
     notify: 'config changed'
-  - name: gather URLs which return redirect from access log
-    shell: "sed -n -e 's/^.*GET \\([^\\?]*\\) HTTP\\/1\\.1. 30[0-9].*$/\\1/p' /var/log/squid/access.log | sort | uniq"
-    changed_when: false
-    check_mode: false
-    register: redirect_urls
-  - name: gather file paths
-    shell: "sed -n -e 's/^.*GET https:\\/\\/[^\\/]*\\(\\/[^\\?]*\\) HTTP\\/1\\.1. 30[0-9].*$/\\1/p' /var/log/squid/access.log | sort | uniq"
-    changed_when: false
-    check_mode: false
-    register: file_paths
   handlers:
   - name: send HUP signal to recconfigure
     shell: kill -HUP 1
@@ -109,24 +124,69 @@
       path: "/etc/nginx/conf.d/default.conf"
       insertafter: "ssl_certificate_key /etc/ssl/private/domain.key;"
       block: |
-        {% set filename = item.split('/')[-1] %}
+        {% filter indent(width=4, first=true) %}
         location {{ item }} {
-          alias /usr/share/nginx/html/downloads/{{ filename }};
+          alias /usr/share/nginx/html/downloads{{ item }};
         }
-      marker: "# {mark} ANSIBLE MANAGED BLOCK for {{ item }}"
-    loop: "{{ hostvars['squid'].file_paths.stdout_lines }}"
+        {% endfilter %}
+      marker: "# {mark} add location directive for {{ item }}"
+    loop: "{{ hostvars['squid'].file_paths_https.stdout_lines }}"
+    notify: 'nginx config changed'
+  - name: insert server directive for port 80
+    blockinfile:
+      path: "/etc/nginx/conf.d/default.conf"
+      insertbefore: BOF
+      block: |
+        server {
+          listen 80;
+          server_name for-redirect-downloads;
+        }
+      marker: "# {mark} add server directive for port 80"
+    notify: 'nginx config changed'
+  - name: insert location directive for port 80
+    blockinfile:
+      path: "/etc/nginx/conf.d/default.conf"
+      insertafter: "server_name for-redirect-downloads"
+      block: |
+        {% filter indent(width=4, first=true) %}
+        location {{ item }} {
+          alias /usr/share/nginx/html/downloads{{ item }};
+        }
+        {% endfilter %}
+      marker: "# {mark} add location directive for {{ item }}"
+    loop: "{{ hostvars['squid'].file_paths_http.stdout_lines }}"
     notify: 'nginx config changed'
   - name: create downloads directory
     file:
       path: /usr/share/nginx/html/downloads
       state: directory
       mode: "755"
+  - name: check existence of directory for redirect file path
+    stat:
+      path: /usr/share/nginx/html/downloads{{ item }}
+    loop: "{{ hostvars['squid'].directory_paths.stdout_lines }}"
+    register: chk_dir
+  - name: create downloads directory for each contents if not exists
+    file:
+      path: /usr/share/nginx/html/downloads{{ item.item }}
+      state: directory
+      mode: "755"
+      recurse: yes
+    when: not (item.stat.exists)
+    loop: "{{ chk_dir.results }}"
+  - name: check existence of download contents for redirect
+    stat:
+      path: /usr/share/nginx/html/downloads/{{ item | regex_replace('^https*://[^/]+/(.*)$','\1') }}
+    loop: "{{ hostvars['squid'].redirect_urls.stdout_lines }}"
+    register: chk_contents
   - name: gather files through redirect
     get_url:
-      url: "{{ item }}"
-      dest: /usr/share/nginx/html/downloads/
+      url: "{{ item.item }}"
+      dest: "{{ item.invocation.module_args.path }}"
       mode: '644'
-    loop: "{{ hostvars['squid'].redirect_urls.stdout_lines }}"
+      force: false
+    when: not (item.stat.exists)
+    loop: "{{ chk_contents.results }}"
     ignore_errors: yes
   handlers:
   - name: send HUP signal to recconfigure

--- a/reset-squid-hosts.yml
+++ b/reset-squid-hosts.yml
@@ -33,11 +33,11 @@
     changed_when: false
     check_mode: false
     register: tls_hosts
-  - name: edit tls_hosts
-    shell: "echo {{ tls_hosts.stdout_lines | join(' ') }} | sed -e 's/registry-mirror\\.offline-cache//g' | sed -e 's/devpi-server\\.offline-cache//g'"
+  - name: gather domains which return redirect from access log
+    shell: "sed -n -e 's/^.*GET https*:\\/\\/\\([^\\/]*\\)\\/[^\\?]* HTTP\\/1\\.1. 30[0-9].*$/\\1/p' /var/log/squid/access.log | sort | uniq"
     changed_when: false
     check_mode: false
-    register: edited_tls_hosts
+    register: redirect_domains
   - name: add entry into hosts file for squid
     lineinfile:
       insertafter: EOF
@@ -48,7 +48,7 @@
         address: "{{ registry_addr.stdout_lines | first }}"
       - name: devpi-server.offline-cache
         address: "{{ devpi_server_addr.stdout_lines | first }}"
-      - name: "{{ edited_tls_hosts.stdout_lines | first }}"
+      - name: "{{ tls_hosts.stdout_lines | union(redirect_domains.stdout_lines) | join(' ') }}"
         address: "{{ nginx_addr.stdout_lines | first }}"
     notify: 'config changed'
   handlers:

--- a/setup.yml
+++ b/setup.yml
@@ -69,26 +69,23 @@
       - { name: client.crt, content: "{{ nssdc_client_cert }}" }
       - { name: client.key, content: "{{ nssdc_client_key }}" }
     when: nssdc_client_cert is defined and nssdc_client_key is defined
-  - name: set client cert to squid
-    blockinfile:
-      path: /etc/squid/squid.conf
-      insertafter: "# tls_outgoing_options flags=DONT_VERIFY_PEER,DONT_VERIFY_DOMAIN"
-      block: |
-        tls_outgoing_options cert=/etc/squid/client_cert/client.crt key=/etc/squid/client_cert/client.key
-      marker: "# {mark} BEGIN ANSIBLE MANAGED BLOCK for client cert and key"
+  - name: setup squid conf for nssdc client cert
+    lineinfile:
+      dest: /etc/squid/squid.conf
+      regexp: "{{ item.key }}"
+      line: "{{ item.value }}"
+    loop:
+    - { key: '# tls_outgoing_options flags=DONT_VERIFY_PEER,DONT_VERIFY_DOMAIN', value: 'tls_outgoing_options cert=/etc/squid/client_cert/client.crt key=/etc/squid/client_cert/client.key' }
     notify: 'config changed'
     when: nssdc_client_cert is defined and nssdc_client_key is defined
-  - name: set maximum object size in squid.conf
+  - name: setup squid conf
     lineinfile:
       dest: /etc/squid/squid.conf
-      regexp: '^maximum_object_size.*'
-      line: 'maximum_object_size 2048 MB'
-    notify: 'config changed'
-  - name: set cache dir in squid.conf
-    lineinfile:
-      dest: /etc/squid/squid.conf
-      regexp: '^cache_dir.*'
-      line: 'cache_dir ufs /var/spool/squid 20000 16 256'
+      regexp: "{{ item.key }}"
+      line: "{{ item.value }}"
+    loop:
+    - { key: '^maximum_object_size.*', value: 'maximum_object_size 2048 MB' }
+    - { key: '^cache_dir.*', value: 'cache_dir ufs /var/spool/squid 20000 16 256' }
     notify: 'config changed'
   handlers:
   - name: send HUP signal to recconfigure


### PR DESCRIPTION
以下の修正を加えました。
・nginxのwarningが出ないように設定ファイルの修正
・リダイレクトダウンロードをローカルのnginxからできるようにする機能がポート443のみ考慮されていたため、ポート80でも可能なように修正
・その他、冪等性を考慮した修正